### PR TITLE
Update Dallas Temp Library dependency to latest

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ monitor_speed = 115200
 
 # http://docs.platformio.org/en/stable/projectconf.html#lib-deps
 lib_deps_external =
-  DallasTemperature @3.7.7
+  DallasTemperature @3.9.0
   EmonLibCM @2.4.0
 
 [env:emontx]


### PR DESCRIPTION
V 3.9.0 is the latest Dallas Temperature Library. 3.7.7 is not listed as a stable release.

https://www.arduino.cc/reference/en/libraries/dallastemperature/