### PR TITLE
Update dependency for EmonLibCM

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ monitor_speed = 115200
 
 # http://docs.platformio.org/en/stable/projectconf.html#lib-deps
 lib_deps_external =
-  DallasTemperature @3.7.7
+  DallasTemperature @3.9.0
   https://github.com/openenergymonitor/EmonLibCM.git#2.4.1
 
 [env:emontx]

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@ monitor_speed = 115200
 # http://docs.platformio.org/en/stable/projectconf.html#lib-deps
 lib_deps_external =
   DallasTemperature @3.7.7
-  EmonLibCM @2.4.0
+  https://github.com/openenergymonitor/EmonLibCM.git#2.4.1
 
 [env:emontx]
 platform = atmelavr


### PR DESCRIPTION
Update the dependency list for EmonLibCM to pull in the latest release.

Use a full path for the dependency so there is no need to download the library separately - PIO will pull it in as part of the build process.

Have the recent releases of EmonTXs not been using the latest CM Library?